### PR TITLE
Use RPi even if not on local LAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Password:
 
 * Boot the device
 * Check that it's on the local network: `$ ping resin.local` or `$ rdt scan`.
+* If it is not on the local network, you can still use the device, but you need to know its IP address.
 
 ### Start the agile services
 * First clone this repo:
@@ -60,6 +61,11 @@ git clone https://github.com/agile-iot/agile-resin & cd /agile-resin
 * Deploy agile services:
 ```
 bash push.sh
+```
+
+If the gateway is not on the local network:
+```
+bash push.sh <IP-address>
 ```
 
 * If everything looks good. Turn on the protocol discovery.

--- a/push.sh
+++ b/push.sh
@@ -1,8 +1,12 @@
+#!/bin/bash
+
+HOST=${1:-resin.local}
+
 # Agile-ble runs the bluetooth service so we must stop the hosts
-ssh root@resin.local -p22222 'systemctl stop bluetooth'
+ssh root@$HOST -p22222 'systemctl stop bluetooth'
 
 export DOCKER_API_VERSION=1.22
-export DOCKER_HOST=tcp://resin.local:2375
+export DOCKER_HOST=tcp://$HOST:2375
 # Because resinos is read-only fs we must write to /mnt/data/
 export DATA=/mnt/data/.agile
 export DBUS_SYSTEM_SOCKET=/var/run/dbus/system_bus_socket


### PR DESCRIPTION
This small change enables to use an RPi even if it is not on the same LAN, given the IP address is known.